### PR TITLE
MBS-10691: Implement teacher-triggered AI (re)grading for qtype_aitext

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -21,6 +21,9 @@ use quizaccess_ai\ai_access_handler;
 /**
  * A rule preventing access to quiz if AI is not available.
  *
+ * When all aitext questions in the quiz have autograde disabled,
+ * this rule does not apply because AI is not needed at submission time.
+ *
  * @package   quizaccess_ai
  * @copyright 2025 ISB Bayern
  * @author    Thomas Schönlein
@@ -39,6 +42,11 @@ class quizaccess_ai extends access_rule_base {
             return null;
         }
 
+        // If all aitext questions have autograde disabled, AI is not needed at submission time.
+        if (self::all_aitext_autograde_disabled($quizobj)) {
+            return null;
+        }
+
         $handler = \core\di::get(ai_access_handler::class);
         if (!$handler->is_aitext_available()) {
             return null;
@@ -53,6 +61,49 @@ class quizaccess_ai extends access_rule_base {
             return null;
         }
         return new self($quizobj, $timenow);
+    }
+
+    /**
+     * Check whether all aitext questions in the quiz have autograde disabled.
+     *
+     * @param quiz_settings $quizobj The quiz settings object.
+     * @return bool True if all aitext questions have autograde=0.
+     */
+    protected static function all_aitext_autograde_disabled(quiz_settings $quizobj): bool {
+        global $DB;
+
+        // If the qtype_aitext table doesn't exist (plugin not installed), we can't check.
+        // In that case, assume autograde is enabled (don't skip the rule).
+        $dbman = $DB->get_manager();
+        if (!$dbman->table_exists('qtype_aitext')) {
+            return false;
+        }
+
+        $quizid = $quizobj->get_quiz()->id;
+
+        $sql = "SELECT DISTINCT q.id, qai.autograde
+                  FROM {quiz_slots} qs
+                  JOIN {question_references} qr ON qr.itemid = qs.id
+                       AND qr.component = 'mod_quiz' AND qr.questionarea = 'slot'
+                  JOIN {question_bank_entries} qbe ON qbe.id = qr.questionbankentryid
+                  JOIN {question_versions} qv ON qv.questionbankentryid = qbe.id
+                  JOIN {question} q ON q.id = qv.questionid
+                  JOIN {qtype_aitext} qai ON qai.questionid = q.id
+                 WHERE qs.quizid = :quizid AND q.qtype = 'aitext'";
+
+        $records = $DB->get_records_sql($sql, ['quizid' => $quizid]);
+
+        if (empty($records)) {
+            return true;
+        }
+
+        foreach ($records as $record) {
+            if (!empty($record->autograde)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     #[\Override]

--- a/tests/rule_test.php
+++ b/tests/rule_test.php
@@ -282,6 +282,53 @@ final class rule_test extends \advanced_testcase {
     }
 
     /**
+     * Ensures make() returns null when all aitext questions have autograde disabled.
+     *
+     * @covers ::make
+     */
+    public function test_make_returns_null_when_all_autograde_disabled(): void {
+        global $DB;
+        $this->resetAfterTest();
+
+        // This test requires qtype_aitext to be installed (it needs the DB table and test helper).
+        $dbman = $DB->get_manager();
+        if (!$dbman->table_exists('qtype_aitext')) {
+            $this->markTestSkipped('qtype_aitext is not installed.');
+        }
+
+        set_config('backend', 'local_ai_manager', 'qtype_aitext');
+        $handler = $this->createMock(ai_access_handler::class);
+        $handler->method('is_aitext_available')->willReturn(true);
+        $handler->method('is_ai_manager_available')->willReturn(true);
+        \core\di::set(ai_access_handler::class, $handler);
+
+        // Create a real course, quiz, and aitext question with autograde=0.
+        $course = $this->getDataGenerator()->create_course();
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
+
+        /** @var \core_question_generator $questiongenerator */
+        $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
+        $category = $questiongenerator->create_question_category([
+            'contextid' => \context_course::instance($course->id)->id,
+        ]);
+        $questiondata = $questiongenerator->create_question('aitext', null, [
+            'category' => $category->id,
+        ]);
+
+        // Set autograde to 0.
+        $DB->set_field('qtype_aitext', 'autograde', 0, ['questionid' => $questiondata->id]);
+
+        quiz_add_quiz_question($questiondata->id, $quiz);
+
+        $quizobj = \mod_quiz\quiz_settings::create($quiz->id);
+        $result = \quizaccess_ai::make($quizobj, time(), false);
+
+        $this->assertNull($result, 'Rule should not apply when all aitext questions have autograde disabled.');
+
+        \core\di::set(ai_access_handler::class, new ai_access_handler());
+    }
+
+    /**
      * Builds a quiz_settings mock for the rule factory tests.
      *
      * @param bool $hasquestions


### PR DESCRIPTION
Add autograde setting to control whether AI feedback is generated automatically on quiz submission or must be triggered manually by a teacher from the grading interface.

Changes:
- New 'autograde' DB field (default: enabled) with upgrade step
- Checkbox in question edit form to toggle automatic AI feedback
- Conditional in grade_response(): skip AI task when autograde=0, set step to 'pending_teacher' state instead
- New trigger_ai_regrade() method with upsert step data handling, runs adhoc task under teacher's identity (model + quota)
- External API (qtype_aitext_trigger_regrade) for single and bulk regrading via AJAX with capability checks
- AMD module (regrade.js) for the regrade button in grading UI
- Renderer: pending_teacher state in feedback(), regrade button in manual_comment() for teachers
- quizaccess_ai: skip access rule when all aitext questions in quiz have autograde disabled
- Lang strings (EN + DE)
- PHPUnit tests with data providers (13 cases): autograde on/off, teacher identity, upsert scenarios, persistence, edge cases
- Behat test for autograde checkbox default and disable flow